### PR TITLE
Hystrix handler ptr to ref

### DIFF
--- a/include/envoy/server/admin.h
+++ b/include/envoy/server/admin.h
@@ -23,7 +23,7 @@ namespace Server {
  */
 #define MAKE_ADMIN_HANDLER(X)                                                                      \
   [this](const std::string& url, Http::HeaderMap& response_headers, Buffer::Instance& data,        \
-         Server::HandlerInfoSharedPtr handler_info) -> Http::Code {                                          \
+         Server::HandlerInfo& handler_info) -> Http::Code {                                          \
     return X(url, response_headers, data, handler_info);                                            \
   }
 
@@ -53,9 +53,15 @@ public:
   virtual ~HystrixHandlerInfo(){};
   void Destroy() {
     if (data_timer_)
+    {
       data_timer_->disableTimer();
+      data_timer_.reset();
+    }
     if (ping_timer_)
+    {
       ping_timer_->disableTimer();
+      ping_timer_.reset();
+    }
   }
 
   /**
@@ -86,7 +92,7 @@ public:
    * @return Http::Code the response code.
    */
   typedef std::function<Http::Code(const std::string& url, Http::HeaderMap& response_headers,
-                                   Buffer::Instance& response, Server::HandlerInfoSharedPtr handler_info)>
+                                   Buffer::Instance& response, Server::HandlerInfo& handler_info)>
       HandlerCb;
 
   /**

--- a/source/common/router/rds_impl.cc
+++ b/source/common/router/rds_impl.cc
@@ -207,7 +207,7 @@ Router::RouteConfigProviderSharedPtr RouteConfigProviderManagerImpl::getRouteCon
 
 Http::Code RouteConfigProviderManagerImpl::handlerRoutes(const std::string& url, Http::HeaderMap&,
                                                          Buffer::Instance& response,
-                                                         Server::HandlerInfoSharedPtr) {
+                                                         Server::HandlerInfo&) {
   Http::Utility::QueryParams query_params = Http::Utility::parseQueryString(url);
   // If there are no query params, print out all the configured route tables.
   if (query_params.size() == 0) {

--- a/source/common/router/rds_impl.h
+++ b/source/common/router/rds_impl.h
@@ -173,7 +173,7 @@ private:
    * @return Http::Code OK if the endpoint can parse and operate on the url, NotFound otherwise.
    */
   Http::Code handlerRoutes(const std::string& path_and_query, Http::HeaderMap& response_headers,
-                           Buffer::Instance& response, Server::HandlerInfoSharedPtr);
+                           Buffer::Instance& response, Server::HandlerInfo&);
 
   /**
    * Helper function used by handlerRoutes. The function loops through the providers

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -41,7 +41,7 @@ public:
             Server::Instance& server, Stats::ScopePtr&& listener_scope);
 
   Http::Code runCallback(const std::string& path_and_query, Http::HeaderMap& response_headers,
-                         Buffer::Instance& response, HandlerInfoSharedPtr handler_info);
+                         Buffer::Instance& response, HandlerInfo& handler_info);
   const Network::ListenSocket& socket() override { return *socket_; }
   Network::ListenSocket& mutable_socket() { return *socket_; }
   Network::ListenerConfig& listener() { return listener_; }
@@ -133,46 +133,46 @@ private:
    * URL handlers.
    */
   Http::Code handlerAdminHome(const std::string& path_and_query, Http::HeaderMap& response_headers,
-                              Buffer::Instance& response, HandlerInfoSharedPtr);
+                              Buffer::Instance& response, HandlerInfo&);
   Http::Code handlerCerts(const std::string& path_and_query, Http::HeaderMap& response_headers,
-                          Buffer::Instance& response, HandlerInfoSharedPtr);
+                          Buffer::Instance& response, HandlerInfo&);
   Http::Code handlerClusters(const std::string& path_and_query, Http::HeaderMap& response_headers,
-                             Buffer::Instance& response, HandlerInfoSharedPtr);
+                             Buffer::Instance& response, HandlerInfo&);
   Http::Code handlerCpuProfiler(const std::string& path_and_query,
                                 Http::HeaderMap& response_headers, Buffer::Instance& response,
-                                HandlerInfoSharedPtr);
+                                HandlerInfo&);
   Http::Code handlerHealthcheckFail(const std::string& path_and_query,
                                     Http::HeaderMap& response_headers, Buffer::Instance& response,
-                                    HandlerInfoSharedPtr);
+                                    HandlerInfo&);
   Http::Code handlerHealthcheckOk(const std::string& path_and_query,
                                   Http::HeaderMap& response_headers, Buffer::Instance& response,
-                                  HandlerInfoSharedPtr);
+                                  HandlerInfo&);
   Http::Code handlerHelp(const std::string& path_and_query, Http::HeaderMap& response_headers,
-                         Buffer::Instance& response, HandlerInfoSharedPtr);
+                         Buffer::Instance& response, HandlerInfo&);
   Http::Code handlerHotRestartVersion(const std::string& path_and_query,
                                       Http::HeaderMap& response_headers, Buffer::Instance& response,
-                                      HandlerInfoSharedPtr);
+                                      HandlerInfo&);
   Http::Code handlerListenerInfo(const std::string& path_and_query,
                                  Http::HeaderMap& response_headers, Buffer::Instance& response,
-                                 HandlerInfoSharedPtr);
+                                 HandlerInfo&);
   Http::Code handlerLogging(const std::string& path_and_query, Http::HeaderMap& response_headers,
-                            Buffer::Instance& response, HandlerInfoSharedPtr);
+                            Buffer::Instance& response, HandlerInfo&);
   Http::Code handlerMain(const std::string& path, Buffer::Instance& response);
   Http::Code handlerQuitQuitQuit(const std::string& path_and_query,
                                  Http::HeaderMap& response_headers, Buffer::Instance& response,
-                                 HandlerInfoSharedPtr);
+                                 HandlerInfo&);
   Http::Code handlerResetCounters(const std::string& path_and_query,
                                   Http::HeaderMap& response_headers, Buffer::Instance& response,
-                                  HandlerInfoSharedPtr);
+                                  HandlerInfo&);
   Http::Code handlerServerInfo(const std::string& path_and_query, Http::HeaderMap& response_headers,
-                               Buffer::Instance& response, HandlerInfoSharedPtr);
+                               Buffer::Instance& response, HandlerInfo&);
   Http::Code handlerStats(const std::string& path_and_query, Http::HeaderMap& response_headers,
-                          Buffer::Instance& response, HandlerInfoSharedPtr);
+                          Buffer::Instance& response, HandlerInfo&);
   Http::Code handlerRuntime(const std::string& path_and_query, Http::HeaderMap& response_headers,
-                            Buffer::Instance& response, HandlerInfoSharedPtr);
+                            Buffer::Instance& response, HandlerInfo&);
   Http::Code handlerHystrixEventStream(const std::string& path_and_query,
                                        Http::HeaderMap& response_headers, Buffer::Instance&,
-                                       HandlerInfoSharedPtr handler_info);
+									   HandlerInfo& handler_info);
 
   class AdminListener : public Network::ListenerConfig {
   public:
@@ -286,7 +286,7 @@ public:
    * (callback, timers, statistics)
    * @param server contains envoy statistics
    */
-  static void updateHystrixRollingWindow(HystrixHandlerInfoSharedPtr hystrix_handler_info, Server::Instance& server);
+  static void updateHystrixRollingWindow(HystrixHandlerInfo* hystrix_handler_info, Server::Instance& server);
   /**
    * Builds a buffer of envoy statistics which will be sent to hystrix dashboard according to
    * hystrix API
@@ -294,13 +294,13 @@ public:
    * (callback, timers, statistics)
    * @param server contains envoy statistics*
    */
-  static void prepareAndSendHystrixStream(HystrixHandlerInfoSharedPtr hystrix_handler_info, Server::Instance& server);
+  static void prepareAndSendHystrixStream(HystrixHandlerInfo* hystrix_handler_info, Server::Instance& server);
   /**
    * Sends a keep alive (ping) message to hystrix dashboard
    * @param hystrix_handler_info is the data which is received in the hystrix handler from the admin filter
    * (callback, timers, statistics)
    */
-  static void sendKeepAlivePing(HystrixHandlerInfoSharedPtr hystrix_handler_info);
+  static void sendKeepAlivePing(HystrixHandlerInfo* hystrix_handler_info);
 };
 
 } // namespace Server


### PR DESCRIPTION
*title*: *one line description*

>Title can be a one or two words to describe the subsystem or the aspect
 this PR applies to. Title and description must be lower case. For example:
* ci: update build image to 44d539cb
* docs: fix indent, buffer: add copyOut() method
* router:add x-envoy-overloaded header
* tls: add support for specifying TLS session ticket keys

*Description*:
>What does this PR do? What was the behavior before the PR?
What is the behavior with the PR? If fixing a bug, please describe what
the original issue is and how the change resolves it. How does this
feature get enabled? By default, config change, etc...

*Risk Level*: Low | Medium | High
>Low: Small bug fix or small optional feature.

>Medium: New features that are not enabled(for example: new filter). Small-medium
features added to existing components(for example: modification to an existing
filter).

>High: Complicated changes such as flow control, rewrites of critical
components, etc.

>Note: The above is only a rough guide for choosing a level,
please ask if you have any concerns about the risk of the PR.

*Testing*:
>Explanation of what testing was done, for example: unit test,
integration, manual testing, etc.

>Note: It isn’t expected to do all
forms of testing, please use your best judgement or ask for guidance
if you are unsure. A good rule of thumb is the riskier the change, the
more comprehensive the testing should be.

*Docs Changes*:
>Link to [Data Plane PR](https://github.com/envoyproxy/data-plane-api/pulls)]
if your PR involves documentation changes. Please write in N/A if there were no
documentation changes.

*Release Notes*:
>If this change is user impacting you **must** add a release note to
[RAW_RELEASE_NOTES.md](RAW_RELEASE_NOTES.md). Thank you! Please write in N/A if
there are no release notes.

[Optional Fixes #Issue]

[Optional *API Changes*:]
>Link to [Data Plane PR](https://github.com/envoyproxy/data-plane-api/pulls)]

[Optional *Deprecated*:]
>Description of what is deprecated.
