### PR TITLE
Hystrix dashboard comments

### DIFF
--- a/include/envoy/server/BUILD
+++ b/include/envoy/server/BUILD
@@ -26,7 +26,6 @@ envoy_cc_library(
         "//include/envoy/http:codes_interface",
         "//include/envoy/http:filter_interface",
         "//include/envoy/network:listen_socket_interface",
-        "//source/common/stats:hystrix_lib",
     ],
 )
 

--- a/include/envoy/server/admin.h
+++ b/include/envoy/server/admin.h
@@ -10,8 +10,6 @@
 #include "envoy/http/header_map.h"
 #include "envoy/network/listen_socket.h"
 
-#include "common/stats/hystrix.h"
-
 namespace Envoy {
 namespace Server {
 
@@ -34,33 +32,12 @@ namespace Server {
  */
 class HandlerInfo {
 public:
-  HandlerInfo(){};
-  virtual ~HandlerInfo(){};
-  virtual void Destroy(){};
+  virtual ~HandlerInfo() {};
+
+  virtual void Destroy() PURE;
 };
+
 typedef std::unique_ptr<HandlerInfo> HandlerInfoPtr;
-
-/**
- * This class contains data which will be sent from admin filter to a hystrix_event_stream handler
- * and build a class which contains the relevant data.
- */
-class HystrixHandlerInfo : public HandlerInfo {
-public:
-  HystrixHandlerInfo(Http::StreamDecoderFilterCallbacks* callbacks)
-      : stats_(new Stats::Hystrix()), data_timer_(nullptr), ping_timer_(nullptr),
-        callbacks_(callbacks) {}
-  virtual ~HystrixHandlerInfo(){};
-  void Destroy();
-
-  /**
-   * HystrixHandlerInfo includes statistics for hystrix API, timers for build (and send) data and
-   * keep alive messages and the handler's callback
-   */
-  Stats::HystrixPtr stats_;
-  Event::TimerPtr data_timer_;
-  Event::TimerPtr ping_timer_;
-  Http::StreamDecoderFilterCallbacks* callbacks_{};
-};
 
 /**
  * Global admin HTTP endpoint for the server.

--- a/source/common/stats/BUILD
+++ b/source/common/stats/BUILD
@@ -75,4 +75,9 @@ envoy_cc_library(
     name = "hystrix_lib",
     srcs = ["hystrix.cc"],
     hdrs = ["hystrix.h"],
+    deps = [
+        "//include/envoy/server:admin_interface",
+        "//include/envoy/server:instance_interface",
+        "//source/common/buffer:buffer_lib",
+    ],
 )

--- a/source/common/stats/hystrix.h
+++ b/source/common/stats/hystrix.h
@@ -2,6 +2,9 @@
 #include <memory>
 #include <vector>
 
+#include "envoy/server/admin.h"
+#include "envoy/server/instance.h"
+
 namespace Envoy {
 namespace Stats {
 
@@ -94,6 +97,61 @@ private:
 };
 
 typedef std::unique_ptr<Hystrix> HystrixPtr;
+
+/**
+ * This class contains data which will be sent from admin filter to a hystrix_event_stream handler
+ * and build a class which contains the relevant data.
+ */
+class HystrixHandlerInfoImpl : public Server::HandlerInfo {
+public:
+  HystrixHandlerInfoImpl(Http::StreamDecoderFilterCallbacks* callbacks)
+      : stats_(new Stats::Hystrix()), data_timer_(nullptr), ping_timer_(nullptr),
+        callbacks_(callbacks) {}
+  virtual ~HystrixHandlerInfoImpl(){};
+  virtual void Destroy();
+
+  /**
+   * HystrixHandlerInfoImpl includes statistics for hystrix API, timers for build (and send) data and
+   * keep alive messages and the handler's callback
+   */
+  Stats::HystrixPtr stats_;
+  Event::TimerPtr data_timer_;
+  Event::TimerPtr ping_timer_;
+  Http::StreamDecoderFilterCallbacks* callbacks_{};
+};
+
+/**
+ * Convert statistics from envoy format to hystrix format and prepare them and writes them to the
+ * appropriate socket
+ */
+class HystrixHandler {
+public:
+  static void HandleEventStream(HystrixHandlerInfoImpl* hystrix_handler_info,
+	                                                Server::Instance& server);
+  /**
+   * Update counter and set values of upstream_rq statistics
+   * @param hystrix_handler_info is the data which is received in the hystrix handler from the admin
+   * filter (callback, timers, statistics)
+   * @param server contains envoy statistics
+   */
+  static void updateHystrixRollingWindow(HystrixHandlerInfoImpl* hystrix_handler_info,
+                                         Server::Instance* server);
+  /**
+   * Builds a buffer of envoy statistics which will be sent to hystrix dashboard according to
+   * hystrix API
+   * @param hystrix_handler_info is the data which is received in the hystrix handler from the admin
+   * filter (callback, timers, statistics)
+   * @param server contains envoy statistics*
+   */
+  static void prepareAndSendHystrixStream(HystrixHandlerInfoImpl* hystrix_handler_info,
+                                          Server::Instance* server);
+  /**
+   * Sends a keep alive (ping) message to hystrix dashboard
+   * @param hystrix_handler_info is the data which is received in the hystrix handler from the admin
+   * filter (callback, timers, statistics)
+   */
+  static void sendKeepAlivePing(HystrixHandlerInfoImpl* hystrix_handler_info);
+};
 
 } // namespace Stats
 } // namespace Envoy

--- a/source/server/http/BUILD
+++ b/source/server/http/BUILD
@@ -47,6 +47,7 @@ envoy_cc_library(
         "//source/common/network:raw_buffer_socket_lib",
         "//source/common/profiler:profiler_lib",
         "//source/common/router:config_lib",
+        "//source/common/stats:hystrix_lib",
         "//source/common/upstream:host_utility_lib",
         "//source/server/config/network:http_connection_manager_lib",
     ],

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -590,7 +590,7 @@ Http::Code AdminImpl::handlerHystrixEventStream(const std::string&,
       Http::Headers::get().AccessControlAllowOriginValue.All);
   response_headers.insertNoChunks().value().setReference("0");
 
-  HystrixHandlerInfo& hystrix_handler_info = dynamic_cast<HystrixHandlerInfo&>(handler_info);
+  HystrixHandlerInfoImpl& hystrix_handler_info = dynamic_cast<HystrixHandlerInfoImpl&>(handler_info);
 
   // start streaming
   hystrix_handler_info.data_timer_ = hystrix_handler_info.callbacks_->dispatcher().createTimer(
@@ -624,11 +624,11 @@ void AdminFilter::onComplete() {
   bool end_stream = true;
 
   if (path.find("/hystrix_event_stream") == std::string::npos) {
-    HandlerInfoPtr temp_handler(new HandlerInfo);
+    HandlerInfoPtr temp_handler(new HandlerInfoImpl);
     handler_info_ = std::move(temp_handler);
     code = parent_.runCallback(path, *header_map, response, *handler_info_);
   } else {
-    HandlerInfoPtr temp_handler(new HystrixHandlerInfo(callbacks_));
+    HandlerInfoPtr temp_handler(new HystrixHandlerInfoImpl(callbacks_));
     handler_info_ = std::move(temp_handler);
     code = parent_.runCallback(path, *header_map, response, *handler_info_);
     end_stream = false;
@@ -848,7 +848,7 @@ bool AdminImpl::removeHandler(const std::string& prefix) {
   return false;
 }
 
-void HystrixHandlerInfo::Destroy() {
+void HystrixHandlerInfoImpl::Destroy() {
   if (data_timer_) {
     data_timer_->disableTimer();
     data_timer_.reset();
@@ -859,7 +859,7 @@ void HystrixHandlerInfo::Destroy() {
   }
 }
 
-void HystrixHandler::updateHystrixRollingWindow(HystrixHandlerInfo* hystrix_handler_info,
+void HystrixHandler::updateHystrixRollingWindow(HystrixHandlerInfoImpl* hystrix_handler_info,
                                                 Server::Instance& server) {
   hystrix_handler_info->stats_->incCounter();
 
@@ -871,7 +871,7 @@ void HystrixHandler::updateHystrixRollingWindow(HystrixHandlerInfo* hystrix_hand
   }
 }
 
-void HystrixHandler::prepareAndSendHystrixStream(HystrixHandlerInfo* hystrix_handler_info,
+void HystrixHandler::prepareAndSendHystrixStream(HystrixHandlerInfoImpl* hystrix_handler_info,
                                                  Server::Instance& server) {
   updateHystrixRollingWindow(hystrix_handler_info, server);
   std::stringstream ss;
@@ -900,7 +900,7 @@ void HystrixHandler::prepareAndSendHystrixStream(HystrixHandlerInfo* hystrix_han
       std::chrono::milliseconds(Stats::Hystrix::GetRollingWindowIntervalInMs()));
 }
 
-void HystrixHandler::sendKeepAlivePing(HystrixHandlerInfo* hystrix_handler_info) {
+void HystrixHandler::sendKeepAlivePing(HystrixHandlerInfoImpl* hystrix_handler_info) {
   Buffer::OwnedImpl data;
   data.add(":\n\n");
 

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -590,24 +590,8 @@ Http::Code AdminImpl::handlerHystrixEventStream(const std::string&,
       Http::Headers::get().AccessControlAllowOriginValue.All);
   response_headers.insertNoChunks().value().setReference("0");
 
-  HystrixHandlerInfoImpl& hystrix_handler_info = dynamic_cast<HystrixHandlerInfoImpl&>(handler_info);
-
-  // start streaming
-  hystrix_handler_info.data_timer_ = hystrix_handler_info.callbacks_->dispatcher().createTimer(
-      [this, &hystrix_handler_info]() -> void {
-        HystrixHandler::prepareAndSendHystrixStream(&hystrix_handler_info, server_);
-      });
-  hystrix_handler_info.data_timer_->enableTimer(
-      std::chrono::milliseconds(Stats::Hystrix::GetRollingWindowIntervalInMs()));
-
-  // start keep alive ping
-  hystrix_handler_info.ping_timer_ =
-      hystrix_handler_info.callbacks_->dispatcher().createTimer([&hystrix_handler_info]() -> void {
-        HystrixHandler::sendKeepAlivePing(&hystrix_handler_info);
-      });
-
-  hystrix_handler_info.ping_timer_->enableTimer(
-      std::chrono::milliseconds(Stats::Hystrix::GetPingIntervalInMs()));
+  Stats::HystrixHandlerInfoImpl& hystrix_handler_info = dynamic_cast<Stats::HystrixHandlerInfoImpl&>(handler_info);
+  Stats::HystrixHandler::HandleEventStream(&hystrix_handler_info,server_);
 
   ENVOY_LOG(debug, "start sending data to hystrix dashboard on port {}",
             hystrix_handler_info.callbacks_->connection()->localAddress()->asString());
@@ -628,7 +612,7 @@ void AdminFilter::onComplete() {
     handler_info_ = std::move(temp_handler);
     code = parent_.runCallback(path, *header_map, response, *handler_info_);
   } else {
-    HandlerInfoPtr temp_handler(new HystrixHandlerInfoImpl(callbacks_));
+    HandlerInfoPtr temp_handler(new Stats::HystrixHandlerInfoImpl(callbacks_));
     handler_info_ = std::move(temp_handler);
     code = parent_.runCallback(path, *header_map, response, *handler_info_);
     end_stream = false;
@@ -846,72 +830,6 @@ bool AdminImpl::removeHandler(const std::string& prefix) {
     return true;
   }
   return false;
-}
-
-void HystrixHandlerInfoImpl::Destroy() {
-  if (data_timer_) {
-    data_timer_->disableTimer();
-    data_timer_.reset();
-  }
-  if (ping_timer_) {
-    ping_timer_->disableTimer();
-    ping_timer_.reset();
-  }
-}
-
-void HystrixHandler::updateHystrixRollingWindow(HystrixHandlerInfoImpl* hystrix_handler_info,
-                                                Server::Instance& server) {
-  hystrix_handler_info->stats_->incCounter();
-
-  for (const Stats::CounterSharedPtr& counter : server.stats().counters()) {
-    // we save all upstream_rq stats.
-    if (counter->name().find("upstream_rq_") != std::string::npos) {
-      hystrix_handler_info->stats_->pushNewValue(counter->name(), counter->value());
-    }
-  }
-}
-
-void HystrixHandler::prepareAndSendHystrixStream(HystrixHandlerInfoImpl* hystrix_handler_info,
-                                                 Server::Instance& server) {
-  updateHystrixRollingWindow(hystrix_handler_info, server);
-  std::stringstream ss;
-  for (auto& cluster : server.clusterManager().clusters()) {
-    hystrix_handler_info->stats_->getClusterStats(
-        ss, cluster.second.get().info()->name(),
-        cluster.second.get()
-            .info()
-            ->resourceManager(Upstream::ResourcePriority::Default)
-            .pendingRequests()
-            .max(),
-        server.stats()
-            .gauge("cluster." + cluster.second.get().info()->name() + ".membership_total")
-            .value());
-  }
-  Buffer::OwnedImpl data;
-  data.add(ss.str());
-
-  // using write() since we are sending network level
-  // TODO(trabetti): is there an alternative to the const_cast?
-  (const_cast<Network::Connection*>((hystrix_handler_info->callbacks_)->connection()))
-      ->write(data, false);
-
-  // restart timer
-  hystrix_handler_info->data_timer_->enableTimer(
-      std::chrono::milliseconds(Stats::Hystrix::GetRollingWindowIntervalInMs()));
-}
-
-void HystrixHandler::sendKeepAlivePing(HystrixHandlerInfoImpl* hystrix_handler_info) {
-  Buffer::OwnedImpl data;
-  data.add(":\n\n");
-
-  // using write() since we are sending network level
-  // TODO(trabetti): is there an alternative to the const_cast?
-  (const_cast<Network::Connection*>((hystrix_handler_info->callbacks_)->connection()))
-      ->write(data, false);
-
-  // restart timer
-  hystrix_handler_info->ping_timer_->enableTimer(
-      std::chrono::milliseconds(Stats::Hystrix::GetPingIntervalInMs()));
 }
 
 } // namespace Server

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -41,28 +41,6 @@ public:
 };
 
 /**
- * This class contains data which will be sent from admin filter to a hystrix_event_stream handler
- * and build a class which contains the relevant data.
- */
-class HystrixHandlerInfoImpl : public HandlerInfo {
-public:
-  HystrixHandlerInfoImpl(Http::StreamDecoderFilterCallbacks* callbacks)
-      : stats_(new Stats::Hystrix()), data_timer_(nullptr), ping_timer_(nullptr),
-        callbacks_(callbacks) {}
-  virtual ~HystrixHandlerInfoImpl(){};
-  virtual void Destroy();
-
-  /**
-   * HystrixHandlerInfoImpl includes statistics for hystrix API, timers for build (and send) data and
-   * keep alive messages and the handler's callback
-   */
-  Stats::HystrixPtr stats_;
-  Event::TimerPtr data_timer_;
-  Event::TimerPtr ping_timer_;
-  Http::StreamDecoderFilterCallbacks* callbacks_{};
-};
-
-/**
  * Implementation of Server::admin.
  */
 class AdminImpl : public Admin,
@@ -312,37 +290,6 @@ private:
    * Take a string and sanitize it according to Prometheus conventions.
    */
   static std::string sanitizeName(const std::string& name);
-};
-
-/**
- * Convert statistics from envoy format to hystrix format and prepare them and writes them to the
- * appropriate socket
- */
-class HystrixHandler {
-public:
-  /**
-   * Update counter and set values of upstream_rq statistics
-   * @param hystrix_handler_info is the data which is received in the hystrix handler from the admin
-   * filter (callback, timers, statistics)
-   * @param server contains envoy statistics
-   */
-  static void updateHystrixRollingWindow(HystrixHandlerInfoImpl* hystrix_handler_info,
-                                         Server::Instance& server);
-  /**
-   * Builds a buffer of envoy statistics which will be sent to hystrix dashboard according to
-   * hystrix API
-   * @param hystrix_handler_info is the data which is received in the hystrix handler from the admin
-   * filter (callback, timers, statistics)
-   * @param server contains envoy statistics*
-   */
-  static void prepareAndSendHystrixStream(HystrixHandlerInfoImpl* hystrix_handler_info,
-                                          Server::Instance& server);
-  /**
-   * Sends a keep alive (ping) message to hystrix dashboard
-   * @param hystrix_handler_info is the data which is received in the hystrix handler from the admin
-   * filter (callback, timers, statistics)
-   */
-  static void sendKeepAlivePing(HystrixHandlerInfoImpl* hystrix_handler_info);
 };
 
 } // namespace Server

--- a/test/common/router/rds_impl_test.cc
+++ b/test/common/router/rds_impl_test.cc
@@ -233,7 +233,7 @@ TEST_F(RdsImplTest, Basic) {
 )EOF";
   EXPECT_EQ("", rds_->versionInfo());
   Http::HeaderMapImpl header_map;
-  Server::HandlerInfo handler_info;
+  Server::HandlerInfoImpl handler_info;
   EXPECT_EQ(Http::Code::OK, handler_callback_("/routes", header_map, data, handler_info));
   EXPECT_EQ(routes_expected_output_no_routes, TestUtility::bufferToString(data));
   data.drain(data.length());
@@ -617,7 +617,7 @@ TEST_F(RouteConfigProviderManagerImplTest, Basic) {
 
   // Test Admin /routes handler.
   Http::HeaderMapImpl header_map;
-  Server::HandlerInfo handler_info;
+  Server::HandlerInfoImpl handler_info;
   EXPECT_EQ(Http::Code::OK, handler_callback_("/routes", header_map, data, handler_info));
   EXPECT_EQ(routes_expected_output, TestUtility::bufferToString(data));
   data.drain(data.length());

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -99,7 +99,7 @@ INSTANTIATE_TEST_CASE_P(IpVersions, AdminInstanceTest,
 TEST_P(AdminInstanceTest, AdminProfiler) {
   Buffer::OwnedImpl data;
   Http::HeaderMapImpl header_map;
-  HandlerInfo handler_info;
+  HandlerInfoImpl handler_info;
   EXPECT_EQ(Http::Code::OK,
             admin_.runCallback("/cpuprofiler?enable=y", header_map, data, handler_info));
   EXPECT_TRUE(Profiler::Cpu::profilerEnabled());
@@ -117,7 +117,7 @@ TEST_P(AdminInstanceTest, AdminBadProfiler) {
                                    "", Network::Test::getCanonicalLoopbackAddress(GetParam()),
                                    server_, listener_scope_.createScope("listener.admin."));
   Http::HeaderMapImpl header_map;
-  HandlerInfo handler_info;
+  HandlerInfoImpl handler_info;
   admin_bad_profile_path.runCallback("/cpuprofiler?enable=y", header_map, data, handler_info);
   EXPECT_FALSE(Profiler::Cpu::profilerEnabled());
 }
@@ -145,7 +145,7 @@ TEST_P(AdminInstanceTest, CustomHandler) {
   EXPECT_TRUE(admin_.addHandler("/foo/bar", "hello", callback, true, false));
   Http::HeaderMapImpl header_map;
   Buffer::OwnedImpl response;
-  HandlerInfo handler_info;
+  HandlerInfoImpl handler_info;
 
   EXPECT_EQ(Http::Code::Accepted,
             admin_.runCallback("/foo/bar", header_map, response, handler_info));
@@ -187,7 +187,7 @@ TEST_P(AdminInstanceTest, EscapeHelpTextWithPunctuation) {
   auto callback = [&](const std::string&, Http::HeaderMap&, Buffer::Instance&,
                       HandlerInfo&) -> Http::Code { return Http::Code::Accepted; };
 
-  HandlerInfo handler_info;
+  HandlerInfoImpl handler_info;
 
   // It's OK to have help text with HTML characters in it, but when we render the home
   // page they need to be escaped.
@@ -207,7 +207,7 @@ TEST_P(AdminInstanceTest, EscapeHelpTextWithPunctuation) {
 TEST_P(AdminInstanceTest, HelpUsesFormForMutations) {
   Http::HeaderMapImpl header_map;
   Buffer::OwnedImpl response;
-  HandlerInfo handler_info;
+  HandlerInfoImpl handler_info;
   EXPECT_EQ(Http::Code::OK, admin_.runCallback("/", header_map, response, handler_info));
   const std::string logging_action = "<form action='/logging' method='post'";
   const std::string stats_href = "<a href='/stats'";
@@ -223,7 +223,7 @@ TEST_P(AdminInstanceTest, Runtime) {
       {"string_key", {"foo", {}}}, {"int_key", {"1", {1}}}, {"other_key", {"bar", {}}}};
   Runtime::MockSnapshot snapshot;
   Runtime::MockLoader loader;
-  HandlerInfo handler_info;
+  HandlerInfoImpl handler_info;
 
   EXPECT_CALL(snapshot, getAll()).WillRepeatedly(testing::ReturnRef(entries));
   EXPECT_CALL(loader, snapshot()).WillRepeatedly(testing::ReturnPointee(&snapshot));
@@ -241,7 +241,7 @@ TEST_P(AdminInstanceTest, RuntimeJSON) {
       {"string_key", {"foo", {}}}, {"int_key", {"1", {1}}}, {"other_key", {"bar", {}}}};
   Runtime::MockSnapshot snapshot;
   Runtime::MockLoader loader;
-  HandlerInfo handler_info;
+  HandlerInfoImpl handler_info;
 
   EXPECT_CALL(snapshot, getAll()).WillRepeatedly(testing::ReturnRef(entries));
   EXPECT_CALL(loader, snapshot()).WillRepeatedly(testing::ReturnPointee(&snapshot));
@@ -277,7 +277,7 @@ TEST_P(AdminInstanceTest, RuntimeBadFormat) {
   std::unordered_map<std::string, const Runtime::Snapshot::Entry> entries;
   Runtime::MockSnapshot snapshot;
   Runtime::MockLoader loader;
-  HandlerInfo handler_info;
+  HandlerInfoImpl handler_info;
 
   EXPECT_CALL(snapshot, getAll()).WillRepeatedly(testing::ReturnRef(entries));
   EXPECT_CALL(loader, snapshot()).WillRepeatedly(testing::ReturnPointee(&snapshot));


### PR DESCRIPTION
*title*: *one line description*

>Title can be a one or two words to describe the subsystem or the aspect
 this PR applies to. Title and description must be lower case. For example:
* ci: update build image to 44d539cb
* docs: fix indent, buffer: add copyOut() method
* router:add x-envoy-overloaded header
* tls: add support for specifying TLS session ticket keys

*Description*:
>What does this PR do? What was the behavior before the PR?
What is the behavior with the PR? If fixing a bug, please describe what
the original issue is and how the change resolves it. How does this
feature get enabled? By default, config change, etc...

*Risk Level*: Low | Medium | High
>Low: Small bug fix or small optional feature.

>Medium: New features that are not enabled(for example: new filter). Small-medium
features added to existing components(for example: modification to an existing
filter).

>High: Complicated changes such as flow control, rewrites of critical
components, etc.

>Note: The above is only a rough guide for choosing a level,
please ask if you have any concerns about the risk of the PR.

*Testing*:
>Explanation of what testing was done, for example: unit test,
integration, manual testing, etc.

>Note: It isn’t expected to do all
forms of testing, please use your best judgement or ask for guidance
if you are unsure. A good rule of thumb is the riskier the change, the
more comprehensive the testing should be.

*Docs Changes*:
>Link to [Data Plane PR](https://github.com/envoyproxy/data-plane-api/pulls)]
if your PR involves documentation changes. Please write in N/A if there were no
documentation changes.

*Release Notes*:
>If this change is user impacting you **must** add a release note to
[RAW_RELEASE_NOTES.md](RAW_RELEASE_NOTES.md). Thank you! Please write in N/A if
there are no release notes.

[Optional Fixes #Issue]

[Optional *API Changes*:]
>Link to [Data Plane PR](https://github.com/envoyproxy/data-plane-api/pulls)]

[Optional *Deprecated*:]
>Description of what is deprecated.
